### PR TITLE
Add "lib" submodule

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ else:
 setup(
     name="coolpuppy",
     version=verstr,
-    packages=["coolpuppy"],
+    packages=["coolpuppy", "coolpuppy.lib"],
     entry_points={
         "console_scripts": [
             "coolpup.py = coolpuppy.CLI:main",


### PR DESCRIPTION
This PR allows `coolpuppy/lib` directory to be included by `pip install` command.